### PR TITLE
PlTracks are replaced with Song instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Created by Liam Kaufman (liamkaufman.com)
 
-Contributions by Liam Kaufman (liamkaufman.com), Steven Miller (copart), dpchu, selftext, z4r, pschorf, Mathew Bramson (mbramson)
+Contributions by Liam Kaufman (liamkaufman.com), Steven Miller (copart), dpchu, selftext, z4r, pschorf, Mathew Bramson (mbramson), Roger Filmyer (rfilmyer)
 
 **Before using pyItunes it is recommended that you backup your Itunes Library XML file. Use pyItunes at your own risk - there is no guarantee that it works or will not blow-up your computer!**
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ iTunes does not count things like Podcasts and Voice Memos as "Music," whereas
 pyitunes counts **all** tracks.
 
 Version 0.2 adds the ability to get playlists. However, the songs dictionary is keyed on TrackID (as coded in iTunes xml).
-
+Playlists are lists of Song objects, with their order noted as a `playlist_order` attribute.
+(note that previously, playlists were lists of PlTrack objects, with their order noted as a `number` attribute. 
+PlTracks have been removed in favor of modified Songs.)
 
 ### Attributes of the Song class:
 
@@ -86,6 +88,12 @@ grouping = None (String)
 lastplayed = None (Time)
 length = None (Integer)
 ```
+
+Songs retrieved as part of a playlist have an additional attribute:
+```
+playlist_order = None (Integer)
+```
+
 
 Song object attributes can be iterated through like this:
 ```

--- a/pyItunes/Library.py
+++ b/pyItunes/Library.py
@@ -122,7 +122,7 @@ class Library:
 						for track in playlist['Playlist Items']:
 							id=int(track['Track ID'])
 							t = self.songs[id]
-							t.number = tracknum #Should this be renamed to playlist_number?
+							t.playlist_order = tracknum
 							tracknum+=1
 							p.tracks.append(t)
 					return p

--- a/pyItunes/Library.py
+++ b/pyItunes/Library.py
@@ -1,5 +1,5 @@
 from pyItunes.Song import Song
-from pyItunes.Playlist import Playlist,PlTrack
+from pyItunes.Playlist import Playlist
 import time
 import plistlib
 from six.moves.urllib import parse as urlparse
@@ -121,15 +121,8 @@ class Library:
 					if 'Playlist Items' in playlist:
 						for track in playlist['Playlist Items']:
 							id=int(track['Track ID'])
-							t = PlTrack()
-							t.number = tracknum
-							t.name = self.songs[id].name
-							t.artist = self.songs[id].artist
-							t.album = self.songs[id].album
-							t.length = self.songs[id].length
-							t.location = self.songs[id].location
-							t.rating = self.songs[id].rating
-							#album
+							t = self.songs[id]
+							t.number = tracknum #Should this be renamed to playlist_number?
 							tracknum+=1
 							p.tracks.append(t)
 					return p

--- a/pyItunes/Playlist.py
+++ b/pyItunes/Playlist.py
@@ -1,11 +1,3 @@
-class PlTrack:
-	location = None
-	name = None
-	artist = None
-	length = None
-	number = None
-	album = None
-
 class Playlist:
 	def __init__(self,playListName=None):
 		self.name = playListName

--- a/pyItunes/__init__.py
+++ b/pyItunes/__init__.py
@@ -1,4 +1,4 @@
 from pyItunes.XMLLibraryParser import XMLLibraryParser
 from pyItunes.Library import Library
 from pyItunes.Song import Song
-from pyItunes.Playlist import Playlist,PlTrack
+from pyItunes.Playlist import Playlist # ,PlTrack


### PR DESCRIPTION
Instead of having two separate classes for tracks, whether they appear in the library or in a playlist, I made them both Song() objects. As discussed in #17, this introduces a small breaking change (`number` on a PlTrack is now `playlist_order` on a Song).