### PR TITLE
Support classical music naming (Work+Movement Number+Movement Name) since iTunes 12.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Created by Liam Kaufman (liamkaufman.com)
 
-Contributions by Liam Kaufman (liamkaufman.com), Steven Miller (copart), dpchu, selftext, z4r, pschorf, Mathew Bramson (mbramson), Roger Filmyer (rfilmyer)
+Contributions by Liam Kaufman (liamkaufman.com), Steven Miller (copart), dpchu, selftext, z4r, pschorf, Mathew Bramson (mbramson), Roger Filmyer (rfilmyer), cktse
 
 **Before using pyItunes it is recommended that you backup your Itunes Library XML file. Use pyItunes at your own risk - there is no guarantee that it works or will not blow-up your computer!**
 
@@ -90,6 +90,10 @@ lastplayed = None (Time)
 skip_count = None (Integer)
 skip_date = None(Time)
 length = None (Integer)
+work = None (String)
+movement_name = None (String)
+movement_number = None (Integer)
+movement_count = None (Integer)
 ```
 
 Songs retrieved as part of a playlist have an additional attribute:

--- a/pyItunes/Library.py
+++ b/pyItunes/Library.py
@@ -38,6 +38,13 @@ class Library:
 		for trackid,attributes in self.il['Tracks'].items():
 			s = Song()
 			s.name = attributes.get('Name')
+
+			# Support classical music naming (Work+Movement Number+Movement Name) since iTunes 12.5
+			s.work = attributes.get('Work')
+			s.movement_number = attributes.get('Movement Number')
+			s.movement_count = attributes.get('Movement Count')
+			s.movement_name = attributes.get('Movement Name')
+
 			s.track_id = int(attributes.get('Track ID'))
 			s.artist = attributes.get('Artist')
 			s.album_artist = attributes.get('Album Artist')

--- a/pyItunes/Song.py
+++ b/pyItunes/Song.py
@@ -33,10 +33,10 @@ class Song:
 	skip_count = None (Integer)
 	skip_date = None (Time)
 	length = None (Integer)
-	persistent_id = None (string)
+	persistent_id = None (String)
 	album_rating_computed = None (Boolean)
-	work = None (string)
-	movement_name = None (string)
+	work = None (String)
+	movement_name = None (String)
 	movement_number = None (Integer)
 	movement_count = None (Integer)
 	"""

--- a/pyItunes/Song.py
+++ b/pyItunes/Song.py
@@ -35,6 +35,10 @@ class Song:
 	length = None (Integer)
 	persistent_id = None (string)
 	album_rating_computed = None (Boolean)
+	work = None (string)
+	movement_name = None (string)
+	movement_number = None (Integer)
+	movement_count = None (Integer)
 	"""
 	name = None
 	track_id = None
@@ -70,6 +74,10 @@ class Song:
 	length = None
 	persistent_id = None
 	album_rating_computed = None
+	work = None
+	movement_name = None
+	movement_number = None
+	movement_count = None
 
 	#title = property(getTitle,setTitle)
 


### PR DESCRIPTION
Support classical music naming (Work+Movement Number+Movement Name) since iTunes 12.5

New Song attributes supported:
- work
- movement_number
- movement_count
- movement_name
