### PR TITLE
Remove unused XMLLibraryParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,20 +26,6 @@ for song in l.getPlaylist(playlists[0]).tracks:
 
 See below for available song attributes.
 
-There is also a deprecated legacy method, which still works for now:
-
-```
-from pyItunes import XMLLibraryParser, Library
-
-pl = XMLLibraryParser("iTunes Library.xml")
-l = Library(pl.dictionary)
-
-for song in l.songs:
-	if song and song.rating:
-		if song.rating > 80:
-			print(song.name)
-```
-
 If your library is very large, reading the XML into memory could be quite slow. If you need to access the library repeatedly, Python's "pickle" can save a binary representation of the XML object to disk for much faster access (up to 10x faster). To use a pickled version, do something like this:
 
 ```

--- a/pyItunes/XMLLibraryParser.py
+++ b/pyItunes/XMLLibraryParser.py
@@ -1,9 +1,0 @@
-#
-# This is file is DEPRECIATED, however, updated here to allow compatability with older code using pyItunes
-#
-import plistlib
-
-class XMLLibraryParser:
-	def __init__(self,xmlLibrary):
-		#Much better support of xml special characters
-		self.dictionary = plistlib.readPlist(xmlLibrary)['Tracks']


### PR DESCRIPTION
I'm not quite sure - if we remove XMLLibraryParser, can we also remove all of the `if legacymode` references? If so, I'll add those changes to this PR. Or does legacymode refer to something else?