### PR TITLE
Restore imports in module init

### DIFF
--- a/pyItunes/__init__.py
+++ b/pyItunes/__init__.py
@@ -1,0 +1,3 @@
+from pyItunes.Library import Library
+from pyItunes.Song import Song
+from pyItunes.Playlist import Playlist


### PR DESCRIPTION
My bad! Earlier I said that I couldn't see how or where the imports in `init` were used, and removed them. It turns out that I actually broke it by doing that, but the breakage was masked by particularities of my setup. The change made it so that you could no longer do:

`from pyItunes import Library`
but had to do this instead:
`from pyItunes.Library import Library`

which of course would break things for existing scripts out there that use this as a dependency. 

Sorry! This PR restores the imports to the init.